### PR TITLE
fix: prevent release workflow failure when changelog entry is missing

### DIFF
--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -55,11 +55,15 @@ jobs:
         id: changelog
         run: |
           VERSION="${{ steps.versions.outputs.version }}"
-          CHANGELOG=$(sed -n "/## \[${VERSION}\]/,/## \[/p" CHANGELOG.md | sed '$d' | tail -n +2)
+          CHANGELOG=$(awk -v version="$VERSION" '
+            $0 ~ "^## \\[" version "\\]" { in_section=1; next }
+            $0 ~ "^## \\[" && in_section { exit }
+            in_section { print }
+          ' CHANGELOG.md)
 
           if [ -z "$CHANGELOG" ]; then
-            echo "No changelog entry found for version $VERSION"
-            exit 1
+            echo "No changelog entry found for version $VERSION, using fallback release note"
+            CHANGELOG="No changelog entry available for this release."
           fi
 
           echo "content<<EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Motivation
- Prevent the release workflow from failing when `CHANGELOG.md` has no entry for the resolved version, so automated releases can still be created.

### Description
- Updated `.github/workflows/merge-and-release.yml` to replace the `sed`-based changelog extraction with an `awk` parser that targets only the matching `## [version]` section.
- When no changelog text is found for the version, the step no longer `exit 1` and instead sets a fallback body: `No changelog entry available for this release.`
- The workflow continues to write the release body to `steps.changelog.outputs.content` and proceeds with build and release steps as before.

### Testing
- Ran `git diff -- .github/workflows/merge-and-release.yml` to verify the exact changes and it displayed the intended patch successfully (success).
- Inspected the updated file with `nl -ba .github/workflows/merge-and-release.yml | sed -n '45,95p'` to confirm the new `awk` logic and fallback behavior (success).
- Verified repository status with `git status --short`, committed the change, and created the PR via the automation tool; all actions completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af77fae5348333b6d3bdcfd199fe05)